### PR TITLE
Breaking: upgrade to abstract-level 2.0.0

### DIFF
--- a/.github/workflows/sauce.yml
+++ b/.github/workflows/sauce.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - name: Install
         run: npm install
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16]
+        node: [16, 18, 20]
     name: Node ${{ matrix.node }}
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -38,19 +38,6 @@ for await (const [key, value] of db.iterator({ gt: 'a' })) {
 }
 ```
 
-With callbacks:
-
-```js
-db.put('example', { hello: 'world' }, (err) => {
-  if (err) throw err
-
-  db.get('example', (err, value) => {
-    if (err) throw err
-    console.log(value) // { hello: 'world' }
-  })
-})
-```
-
 <!-- ## Browser support
 
 [![Sauce Test Status](https://app.saucelabs.com/browser-matrix/level-ci.svg)](https://app.saucelabs.com/u/level-ci) -->

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,10 @@
 
 This document describes breaking changes and how to upgrade. For a complete list of changes including minor and patch releases, please refer to the [`CHANGELOG`](CHANGELOG.md).
 
+## 2.0.0
+
+This release upgrades to `abstract-level` 2.0.0 which adds [hooks](https://github.com/Level/abstract-level#hooks) and drops callbacks, not-found errors and support of Node.js < 16. Please refer to the [upgrade guide of `abstract-level`](https://github.com/Level/abstract-level/blob/v2.0.0/UPGRADING.md).
+
 ## 1.0.0
 
 **Introducing `memory-level`: a fork of [`memdown`](https://github.com/Level/memdown) that removes the need for [`level-mem`](https://github.com/Level/mem), [`levelup`](https://github.com/Level/levelup) and more. It implements the [`abstract-level`](https://github.com/Level/abstract-level) interface instead of [`abstract-leveldown`](https://github.com/Level/abstract-leveldown) and thus has the same API as `level-mem` and `levelup` including encodings, promises and events. In addition, you can now choose to use Uint8Array instead of Buffer. Sublevels are builtin.**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,7 @@
 import {
   AbstractLevel,
   AbstractDatabaseOptions,
-  AbstractOpenOptions,
-  NodeCallback
+  AbstractOpenOptions
 } from 'abstract-level'
 
 /**
@@ -22,8 +21,6 @@ export class MemoryLevel<KDefault = string, VDefault = string>
 
   open (): Promise<void>
   open (options: OpenOptions): Promise<void>
-  open (callback: NodeCallback<void>): void
-  open (options: OpenOptions, callback: NodeCallback<void>): void
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -263,18 +263,10 @@ for (const Ctor of [MemoryIterator, MemoryKeyIterator, MemoryValueIterator]) {
 }
 
 class MemoryLevel extends AbstractLevel {
-  constructor (location, options, _) {
+  constructor (location, options) {
     // Take a dummy location argument to align with other implementations
     if (typeof location === 'object' && location !== null) {
       options = location
-    }
-
-    // To help migrating from level-mem to abstract-level
-    // TODO (v2): remove
-    if (typeof location === 'function' || typeof options === 'function' || typeof _ === 'function') {
-      throw new ModuleError('The levelup-style callback argument has been removed', {
-        code: 'LEVEL_LEGACY'
-      })
     }
 
     let { storeEncoding, ...forward } = options || {}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "main": "index.js",
   "types": "./index.d.ts",
   "scripts": {
-    "test": "standard && hallmark && (nyc -s node test.js | faucet) && nyc report",
+    "test": "standard && hallmark && (nyc -s node test.js | tap-arc) && nyc report",
+    "test-pessimistic": "node test.js | tap-arc -pv",
     "test-browsers": "airtap --coverage --verbose test.js",
     "test-browsers-local": "airtap --coverage -p local test.js",
     "coverage": "nyc report -r lcovonly"
@@ -19,22 +20,22 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "abstract-level": "^1.0.0",
+    "abstract-level": "^2.0.1",
     "functional-red-black-tree": "^1.0.1",
     "module-error": "^1.0.1"
   },
   "devDependencies": {
-    "@voxpelli/tsconfig": "^4.0.0",
+    "@voxpelli/tsconfig": "^15.0.0",
     "airtap": "^4.0.3",
     "airtap-playwright": "^1.0.1",
     "airtap-sauce": "^1.1.0",
     "buffer": "^6.0.3",
-    "faucet": "^0.0.3",
     "hallmark": "^4.0.0",
     "nyc": "^15.1.0",
     "standard": "^17.0.0",
+    "tap-arc": "^0.3.5",
     "tape": "^5.0.1",
-    "typescript": "^4.5.5"
+    "typescript": "^5.6.3"
   },
   "repository": {
     "type": "git",
@@ -49,6 +50,6 @@
     "memory"
   ],
   "engines": {
-    "node": ">=12"
+    "node": ">=16"
   }
 }

--- a/test.js
+++ b/test.js
@@ -22,24 +22,16 @@ for (const storeEncoding of ['view', 'utf8']) {
 }
 
 // Additional tests for this implementation of abstract-level
-test('iterator does not clone buffers', function (t) {
+test('iterator does not clone buffers', async function (t) {
   const db = new MemoryLevel({ keyEncoding: 'buffer', valueEncoding: 'buffer' })
   const buf = Buffer.from('a')
 
-  db.open(function (err) {
-    t.ifError(err, 'no open() error')
+  await db.open()
+  await db.put(buf, buf)
 
-    db.put(buf, buf, function (err) {
-      t.ifError(err, 'no put() error')
-
-      db.iterator().all(function (err, entries) {
-        t.ifError(err, 'no all() error')
-        t.is(entries[0][0], buf, 'key is same buffer')
-        t.is(entries[0][1], buf, 'value is same buffer')
-        t.end()
-      })
-    })
-  })
+  const entries = await db.iterator().all()
+  t.is(entries[0][0], buf, 'key is same buffer')
+  t.is(entries[0][1], buf, 'value is same buffer')
 })
 
 test('throws on unsupported storeEncoding', function (t) {

--- a/test.js
+++ b/test.js
@@ -38,10 +38,3 @@ test('throws on unsupported storeEncoding', function (t) {
   t.throws(() => new MemoryLevel({ storeEncoding: 'foo' }), (err) => err.code === 'LEVEL_ENCODING_NOT_SUPPORTED')
   t.end()
 })
-
-test('throws on legacy level-mem options', function (t) {
-  t.throws(() => new MemoryLevel(() => {}), (err) => err.code === 'LEVEL_LEGACY')
-  t.throws(() => new MemoryLevel('x', () => {}), (err) => err.code === 'LEVEL_LEGACY')
-  t.throws(() => new MemoryLevel('x', {}, () => {}), (err) => err.code === 'LEVEL_LEGACY')
-  t.end()
-})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@voxpelli/tsconfig/node12.json",
+  "extends": "@voxpelli/tsconfig/node16.json",
   "compilerOptions": {
     "checkJs": false
   },


### PR DESCRIPTION
One of the `abstract-level` tests fails (data comes out as a buffer or view but `abstract-level` expects a string), need to check why.

```
prewrite hook function can write to nondescendant sublevel
    ✖ 8059) should be deeply equivalent
      @@ -1,1 +1,1 @@
      -"[ '!books!12', '!authors!\"Hesse~12\"' ]"
      +"[ Uint8Array [Uint8Array] { 0: 33, 1: 98, 2: 111, 3: 111, 4: 107, 5: 115, 6: 33, 7: 49, 8: 50 }, Uint8Array [Uint8Array] { 0: 33, 1: 97, 2: 117, 3: 116, 4: 104, 5: 111, 6: 114, 7: 115, 8: 33, 9: 34, 10: 72, 11: 101, 12: 115, 13: 115, 14: 101, 15: 126, 16: 49, 17: 50, 18: 34 } ]"
      At: AbstractSublevel.<anonymous> (\node_modules\abstract-level\test\hooks\prewrite.js:782:9)
```

Other than that this is a straight forward change.