### PR TITLE
Implement `has()` and `hasMany()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -284,6 +284,7 @@ class MemoryLevel extends AbstractLevel {
       permanence: false,
       createIfMissing: false,
       errorIfExists: false,
+      has: true,
       encodings: { [storeEncoding]: true },
       signals: {
         // Would have no value here because the operations are synchronous
@@ -311,6 +312,20 @@ class MemoryLevel extends AbstractLevel {
 
   async _getMany (keys, options) {
     return keys.map(key => this[kTree].get(key))
+  }
+
+  async _has (key, options) {
+    const tree = options.snapshot != null
+      ? options.snapshot[kTree]
+      : this[kTree]
+    return tree.get(key) !== undefined
+  }
+
+  async _hasMany (keys, options) {
+    const tree = options.snapshot != null
+      ? options.snapshot[kTree]
+      : this[kTree]
+    return keys.map(has, tree)
   }
 
   async _del (key, options) {
@@ -393,4 +408,8 @@ if (typeof process !== 'undefined' && !process.browser && typeof global !== 'und
 
 function isRangeOption (k) {
   return rangeOptions.has(k)
+}
+
+function has (key) {
+  return this.get(key) !== undefined
 }


### PR DESCRIPTION
Adds support of two methods:

```js
await db.put('love', 'u')
await db.has('love') // true
await db.hasMany(['love', 'hate']) // [true, false]
```

Ref: https://github.com/Level/community/issues/142